### PR TITLE
Allow operator to specify a Consul ACL token

### DIFF
--- a/cluster/consul.go
+++ b/cluster/consul.go
@@ -1,0 +1,13 @@
+package cluster
+
+import (
+	"github.com/armon/consul-api"
+)
+
+func NewConsulClient(token string) *consulapi.Client {
+	config := consulapi.DefaultConfig()
+	config.Token = token
+
+	client, _ := consulapi.NewClient(config)
+	return client
+}

--- a/cluster/consul_node.go
+++ b/cluster/consul_node.go
@@ -23,6 +23,8 @@ type ConsulNodeConfig struct {
 	AdvertiseAddr string
 	ListenPort    int
 	DataPath      string
+	ConsulToken   string
+	RoutingPrefix string
 }
 
 func (cn *ConsulNodeConfig) Normalize() error {
@@ -41,6 +43,10 @@ func (cn *ConsulNodeConfig) Normalize() error {
 
 	if cn.DataPath == "" {
 		cn.DataPath = DefaultPath
+	}
+
+	if cn.RoutingPrefix == "" {
+		cn.RoutingPrefix = DefaultRoutingPrefix
 	}
 
 	return nil
@@ -64,7 +70,9 @@ func NewConsulClusterNode(config *ConsulNodeConfig) (*ConsulClusterNode, error) 
 		return nil, err
 	}
 
-	ct, err := NewConsulRoutingTable(config.AdvertiseID())
+	consul := NewConsulClient(config.ConsulToken)
+
+	ct, err := NewConsulRoutingTable(config.RoutingPrefix, config.AdvertiseID(), consul)
 	if err != nil {
 		return nil, err
 	}

--- a/cluster/consul_routing.go
+++ b/cluster/consul_routing.go
@@ -7,6 +7,7 @@ import (
 
 	"sync"
 
+	"github.com/armon/consul-api"
 	"github.com/vektra/consul_kv_cache/cache"
 	"github.com/vektra/vega"
 )
@@ -33,14 +34,14 @@ type consulRoutingTable struct {
 	cache map[string]*cachedPusher
 }
 
-var ConsulRoutingPrefix = "mailbox-routing"
+var DefaultRoutingPrefix = "mailbox-routing"
 
-func NewConsulRoutingTable(id string) (*consulRoutingTable, error) {
+func NewConsulRoutingTable(prefix, id string, client *consulapi.Client) (*consulRoutingTable, error) {
 	h := sha1.New()
 	h.Write([]byte(id))
 	k := hex.EncodeToString(h.Sum(nil))
 
-	consul := cache.NewConsulKVCache(ConsulRoutingPrefix)
+	consul := cache.NewCustomConsulKVCache(prefix, client)
 
 	go consul.BackgroundUpdate()
 

--- a/cmd/vegad/vegad.go
+++ b/cmd/vegad/vegad.go
@@ -15,7 +15,9 @@ var fPort = flag.Int("port", vega.DefaultPort, "port to listen on localhost")
 var fClusterPort = flag.Int("cluster-port", cluster.DefaultClusterPort, "port to listen on for cluster membership")
 var fHttpPort = flag.Int("http-port", vega.DefaultHTTPPort, "port to listen on")
 var fData = flag.String("data-dir", cluster.DefaultPath, "path to store data in")
-var fAdvertise = flag.String("advertise", "", "Address to advertise vega on")
+var fAdvertise = flag.String("advertise", "", "address to advertise vega on")
+var fRoutingPrefix = flag.String("routing-prefix", cluster.DefaultRoutingPrefix, "prefix to store the routing table under")
+var fToken = flag.String("consul-token", "", "consul acl token to use")
 
 func main() {
 	flag.Parse()
@@ -24,6 +26,8 @@ func main() {
 		ListenPort:    *fClusterPort,
 		DataPath:      *fData,
 		AdvertiseAddr: *fAdvertise,
+		RoutingPrefix: *fRoutingPrefix,
+		ConsulToken:   *fToken,
 	}
 
 	node, err := cluster.NewConsulClusterNode(cfg)


### PR DESCRIPTION
This is a solution to vektra/vega/issues/4. It requires vektra/consul_kv_cache/pull/1 to be merged first.

Also:
- Allow a custom routing prefix to be specified
